### PR TITLE
merge

### DIFF
--- a/export.py
+++ b/export.py
@@ -7,7 +7,7 @@ from telegram import MessageEntity
 import export_to_telegraph
 from html_telegraph_poster import TelegraphPoster
 import yaml
-from telegram_util import matchKey, log_on_fail, log, tryDelete, autoDestroy, getDisplayChatHtml
+from telegram_util import matchKey, log_on_fail, log, tryDelete, autoDestroy, getBasicLog
 import plain_db
 from bs4 import BeautifulSoup
 
@@ -67,6 +67,7 @@ def exportImp(msg):
 		if 'http' in item.get('href'):
 			url = item.get('href')
 			result = getTelegraph(msg, url)
+			yield result
 			if str(msg.chat_id) in no_source_link._db.items:
 				msg.chat.send_message(result)
 			else:
@@ -91,8 +92,9 @@ def export(update, context):
 	except:
 		return
 	error = ''
+	result = []
 	try:
-		exportImp(msg)
+		result = list(exportImp(msg))
 		if msg.chat.username == 'web_record':
 			tryDelete(msg)
 	except Exception as e:
@@ -100,9 +102,8 @@ def export(update, context):
 		autoDestroy(tmp_msg_2, 0.05)
 		error = ' error: ' + str(e)
 	finally:
-		info_log.send_message('id: %d chat: %s%s content: %s' % (
-			msg.chat.id, getDisplayChatHtml(msg.chat), error, msg.text_html_urled), 
-			parse_mode='html')
+		info_log.send_message(getBasicLog(msg) + error + ' result: ' + ' '.join(result),
+			parse_mode='html', disable_web_page_preview=True)
 		tmp_msg_1.delete()
 
 with open('help.md') as f:

--- a/export.py
+++ b/export.py
@@ -20,6 +20,7 @@ info_log = tele.bot.get_chat(-1001436325054)
 no_auth_link_users = [-1001399998441] # prevent token leak through @web_record
 
 no_source_link = plain_db.loadKeyOnlyDB('no_source_link')
+remove_origin = plain_db.loadKeyOnlyDB('remove_origin')
 
 with open('telegraph_tokens') as f:
 	telegraph_tokens = {}
@@ -85,7 +86,6 @@ def export(update, context):
 		if (matchKey(msg.text_markdown, ['twitter', 'weibo', 
 				'douban', 't.me/']) and 
 				not matchKey(msg.text_markdown, ['article', 'note'])):
-			tryDelete(msg)
 			return
 	try:
 		tmp_msg_1 = msg.chat.send_message('received')
@@ -95,7 +95,7 @@ def export(update, context):
 	result = []
 	try:
 		result = list(exportImp(msg))
-		if msg.chat.username == 'web_record':
+		if str(msg.chat.id) in remove_origin._db.items:
 			tryDelete(msg)
 	except Exception as e:
 		tmp_msg_2 = msg.chat.send_message(str(e))
@@ -116,13 +116,23 @@ def toggleSourceLink(msg):
 	else:
 		msg.reply_text('Source Link On')
 
+def toggleRemoveOrigin(msg):
+	result = remove_origin.toggle(msg.chat_id)
+	if result:
+		msg.reply_text('Remove Original message Off')
+	else:
+		msg.reply_text('Remove Original message On')
+
 @log_on_fail(debug_group)
 def command(update, context):
 	msg = update.message
+	print(msg)
 	if matchKey(msg.text, ['auth', 'token']):
 		return msgTelegraphToken(msg)
-	if matchKey(msg.text, ['toggle', 'source']):
+	if matchKey(msg.text, ['source', 'tnsl', 'toggle_no_source_link']):
 		return toggleSourceLink(msg)
+	if matchKey(msg.text, ['origin', 'trmo', 'toggle_remove_origin']):
+		return toggleRemoveOrigin(msg)
 	if msg.chat_id > 0:
 		msg.reply_text(help_message)
 

--- a/export.py
+++ b/export.py
@@ -60,6 +60,7 @@ def getTelegraph(msg, url):
 	return export_to_telegraph.export(url, throw_exception = True, 
 		force = True, toSimplified = (
 			'bot_simplify' in msg.text or msg.text.endswith(' s')),
+		noAutoConvert = msg.text.endswith(' t') or msg.text.endswith(' noAutoConvert'),
 		noSourceLink = str(msg.chat_id) in no_source_link._db.items)
 
 def exportImp(msg):

--- a/export.py
+++ b/export.py
@@ -119,14 +119,13 @@ def toggleSourceLink(msg):
 def toggleRemoveOrigin(msg):
 	result = remove_origin.toggle(msg.chat_id)
 	if result:
-		msg.reply_text('Remove Original message Off')
-	else:
 		msg.reply_text('Remove Original message On')
+	else:
+		msg.reply_text('Remove Original message Off')
 
 @log_on_fail(debug_group)
 def command(update, context):
-	msg = update.message
-	print(msg)
+	msg = update.message or update.channel_post
 	if matchKey(msg.text, ['auth', 'token']):
 		return msgTelegraphToken(msg)
 	if matchKey(msg.text, ['source', 'tnsl', 'toggle_no_source_link']):

--- a/export.py
+++ b/export.py
@@ -7,13 +7,15 @@ from telegram import MessageEntity
 import export_to_telegraph
 from html_telegraph_poster import TelegraphPoster
 import yaml
-from telegram_util import matchKey, log_on_fail, log, tryDelete
+from telegram_util import matchKey, log_on_fail, log, tryDelete, autoDestroy, getDisplayChatHtml
 import plain_db
+from bs4 import BeautifulSoup
 
 with open('token') as f:
     tele = Updater(f.read().strip(), use_context=True)
 
 debug_group = tele.bot.get_chat(420074357)
+info_log = tele.bot.get_chat(-1001436325054)
 
 no_auth_link_users = [-1001399998441] # prevent token leak through @web_record
 
@@ -60,11 +62,10 @@ def getTelegraph(msg, url):
 		noSourceLink = str(msg.chat_id) in no_source_link._db.items)
 
 def exportImp(msg):
-	for item in msg.entities:
-		if (item["type"] == "url"):
-			url = msg.text[item["offset"]:][:item["length"]]
-			if not '://' in url:
-				url = "https://" + url
+	soup = BeautifulSoup(msg.text_html_urled, 'html.parser')
+	for item in soup.find_all('a'):
+		if 'http' in item.get('href'):
+			url = item.get('href')
 			result = getTelegraph(msg, url)
 			if str(msg.chat_id) in no_source_link._db.items:
 				msg.chat.send_message(result)
@@ -77,7 +78,7 @@ def export(update, context):
 	if update.edited_message or update.edited_channel_post:
 		return
 	msg = update.effective_message
-	if msg.chat_id < 0 and ('source' in msg.text) and ('[source]' in msg.text_markdown):
+	if msg.chat_id < 0 and 'source</a>' in msg.text_html_urled:
 		return
 	if msg.chat.username == 'web_record':
 		if (matchKey(msg.text_markdown, ['twitter', 'weibo', 
@@ -86,19 +87,23 @@ def export(update, context):
 			tryDelete(msg)
 			return
 	try:
-		r = msg.chat.send_message('received')
+		tmp_msg_1 = msg.chat.send_message('received')
 	except:
 		return
+	error = ''
 	try:
 		exportImp(msg)
 		if msg.chat.username == 'web_record':
 			tryDelete(msg)
 	except Exception as e:
-		msg.chat.send_message(str(e))
-		if not matchKey(str(e), ['Content is too big.']):
-			raise e
+		tmp_msg_2 = msg.chat.send_message(str(e))
+		autoDestroy(tmp_msg_2, 0.05)
+		error = ' error: ' + str(e)
 	finally:
-		r.delete()
+		info_log.send_message('id: %d chat: %s%s content: %s' % (
+			msg.chat.id, getDisplayChatHtml(msg.chat), error, msg.text_html_urled), 
+			parse_mode='html')
+		tmp_msg_1.delete()
 
 with open('help.md') as f:
 	help_message = f.read()

--- a/export.py
+++ b/export.py
@@ -56,9 +56,9 @@ def msgTelegraphToken(msg):
 
 def getAlbum(msg, url):
 	if msg.text.endswith(' f') or msg.text.endswith(' full'):
-		return export_to_telegraph.getAlbum(url, word_limit=1024, paragraph_limit=20)
+		return export_to_telegraph.getAlbum(url, word_limit=1000, paragraph_limit=20, append_source=True, append_url=False)
 	if msg.text.endswith(' b') or msg.text.endswith(' brief'):
-		return export_to_telegraph.getAlbum(url)
+		return export_to_telegraph.getAlbum(url, append_source=True, append_url=False)
 
 def getTelegraph(msg, url):
 	source_id, _, _ = getSource(msg)

--- a/export.py
+++ b/export.py
@@ -111,8 +111,11 @@ def export(update, context):
 		if str(msg.chat.id) in remove_origin._db.items:
 			tryDelete(msg)
 	except Exception as e:
-		tmp_msg_2 = msg.chat.send_message(str(e))
-		autoDestroy(tmp_msg_2, 0.05)
+		try:
+			tmp_msg_2 = msg.chat.send_message(str(e)) 
+			autoDestroy(tmp_msg_2, 0.05)
+		except:
+			... # In flood case, this would fail also
 		error = ' error: ' + str(e)
 	finally:
 		info_log.send_message(getBasicLog(msg) + error + ' result: ' + ' '.join(result),

--- a/export.py
+++ b/export.py
@@ -55,7 +55,7 @@ def msgTelegraphToken(msg):
 
 
 def getAlbum(msg, url):
-	if msg.text.endswith(' f') or msg.text.endswith(' full'):
+	if msg.text.endswith(' f') or msg.text.endswith(' full') or msg.text.endswith(' l'):
 		return export_to_telegraph.getAlbum(url, word_limit=1000, paragraph_limit=20, append_source=True, append_url=False)
 	if msg.text.endswith(' b') or msg.text.endswith(' brief'):
 		return export_to_telegraph.getAlbum(url, append_source=True, append_url=False)


### PR DESCRIPTION
`getAlbum`、`noAutoConvert` 和 `remove_origin` 应该都只是为了采集而准备的功能，普通用户可能用不到，因此不先引入。

使用 HTML 代替 MD 格式化消息，应该是为了配合 `getAlbum`，故也不引入。